### PR TITLE
Permanently delete topics with annotation set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ canary:
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+mocks:
+	cd pkg/aiven && mockery -inpkg -all -case snake
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="code-generation/header.go.txt" paths="./..."

--- a/api/v1/hash.go
+++ b/api/v1/hash.go
@@ -7,8 +7,22 @@ import (
 	hash "github.com/mitchellh/hashstructure"
 )
 
-func (in *TopicSpec) Hash() (string, error) {
-	marshalled, err := json.Marshal(in)
+func (in *Topic) Hash() (string, error) {
+	type hashFields struct {
+		Annotations map[string]string
+		Spec        TopicSpec
+	}
+	annotations := in.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	data := hashFields{
+		Annotations: map[string]string{
+			RemoveDataAnnotation: annotations[RemoveDataAnnotation],
+		},
+		Spec: in.Spec,
+	}
+	marshalled, err := json.Marshal(data)
 	if err != nil {
 		return "", err
 	}

--- a/api/v1/hash_test.go
+++ b/api/v1/hash_test.go
@@ -8,8 +8,15 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	spec := kafka_nais_io_v1.TopicSpec{}
+	spec := kafka_nais_io_v1.Topic{}
 	hash, err := spec.Hash()
 	assert.NoError(t, err)
-	assert.Equal(t, "dd7b6d7c6d11a91f", hash)
+	assert.Equal(t, "45bb0c5791695f91", hash)
+
+	spec.Annotations = map[string]string{
+		kafka_nais_io_v1.RemoveDataAnnotation: "true",
+	}
+	hash, err = spec.Hash()
+	assert.NoError(t, err)
+	assert.Equal(t, "89b3de1b2598c91c", hash)
 }

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -68,6 +68,7 @@ type aivenUpdated struct {
 }
 
 type aivenDeleted struct {
+	Topics       []string
 	Serviceusers []string
 	Acls         []string
 }
@@ -175,6 +176,12 @@ func aivenMockInterfaces(test testCase) kafkarator_aiven.Interfaces {
 				Return(nil)
 		}
 
+		for _, t := range test.Aiven.Deleted.Topics {
+			topicMock.
+				On("Delete", project, svc, t).
+				Return(nil)
+		}
+
 		for _, u := range test.Aiven.Deleted.Serviceusers {
 			serviceUserMock.
 				On("Delete", project, svc, u).
@@ -250,6 +257,7 @@ func yamlSubTest(t *testing.T, path string) {
 	// hard to test current time with static data
 	test.Output.Status.CredentialsExpiryTime = result.Status.CredentialsExpiryTime
 	test.Output.Status.SynchronizationTime = result.Status.SynchronizationTime
+	test.Output.Status.SynchronizationHash = result.Status.SynchronizationHash
 
 	assert.Equal(t, test.Output.Status, result.Status)
 	assert.Equal(t, test.Output.Requeue, result.Requeue)

--- a/controllers/testdata/change_acl.yaml
+++ b/controllers/testdata/change_acl.yaml
@@ -64,7 +64,6 @@ topic:
 output:
   status:
     synchronizationState: RolloutComplete
-    synchronizationHash: 5b9b9ebe3a8508d5
     message: Topic configuration synchronized to Kafka pool
   secrets:
     - apiVersion: v1

--- a/controllers/testdata/greenfield.yaml
+++ b/controllers/testdata/greenfield.yaml
@@ -56,7 +56,6 @@ topic:
 output:
   status:
     synchronizationState: RolloutComplete
-    synchronizationHash: c68032f161f62b60
     message: Topic configuration synchronized to Kafka pool
   secrets:
     - apiVersion: v1

--- a/controllers/testdata/permanently_delete_topic.yaml
+++ b/controllers/testdata/permanently_delete_topic.yaml
@@ -1,0 +1,48 @@
+config:
+  description: topic is permanently deleted when annotation is set
+  projects:
+    - nav-integration-test
+
+aiven:
+  existing:
+    topics:
+      - topic_name: myteam.mytopic
+        retention_hours: 900
+        replication: 3
+    service:
+      name: nav-integration-test
+      service_uri: well-known-kafka-brokers:12345
+      connection_info:
+        schema_registry_uri: https://schema-registry.tld:9876
+    ca: well-known-certificate-authority
+  created: {}
+  updated: {}
+  deleted:
+    topics:
+      - myteam.mytopic
+
+topic:
+  apiVersion: kafka.nais.io/v1
+  kind: Topic
+  metadata:
+    name: mytopic
+    namespace: myteam
+    annotations:
+      kafka.nais.io/removeDataWhenResourceIsDeleted: "true"
+    deletionTimestamp: 1970-01-01T00:00:00Z
+    labels:
+      team: myteam
+  spec:
+    pool: nav-integration-test
+    config:
+      retentionHours: 12
+      partitions: 2
+    acl:
+      - access: read
+        team: myteam
+        application: myapplication
+
+output:
+  deleteFinalized: true
+  status:
+    message: Topic and data permanently deleted

--- a/controllers/testdata/update_topic_config.yaml
+++ b/controllers/testdata/update_topic_config.yaml
@@ -59,7 +59,6 @@ topic:
 output:
   status:
     synchronizationState: RolloutComplete
-    synchronizationHash: 1c3a7a5f0371bc8a
     message: Topic configuration synchronized to Kafka pool
   secrets:
     - apiVersion: v1

--- a/examples/topic.yaml
+++ b/examples/topic.yaml
@@ -2,18 +2,20 @@
 apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
+  annotations:
+    kafka.nais.io/removeDataWhenResourceIsDeleted: "true"
   name: mytopic
-  namespace: aura
+  namespace: default
   labels:
-    team: aura
+    team: default
 spec:
   pool: nav-integration-test
   config:
     retentionHours: 900
   acl:
     - access: read
-      team: aura
+      team: default
       application: myapplication
     - access: write
-      team: aura
+      team: default
       application: otherapplication

--- a/pkg/aiven/topic/mock_interface.go
+++ b/pkg/aiven/topic/mock_interface.go
@@ -26,6 +26,20 @@ func (_m *MockInterface) Create(project string, service string, req aiven.Create
 	return r0
 }
 
+// Delete provides a mock function with given fields: project, service, topic
+func (_m *MockInterface) Delete(project string, service string, topic string) error {
+	ret := _m.Called(project, service, topic)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(project, service, topic)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Get provides a mock function with given fields: project, service, topic
 func (_m *MockInterface) Get(project string, service string, topic string) (*aiven.KafkaTopic, error) {
 	ret := _m.Called(project, service, topic)

--- a/pkg/aiven/topic/topic.go
+++ b/pkg/aiven/topic/topic.go
@@ -15,6 +15,7 @@ type Interface interface {
 	List(project, service string) ([]*aiven.KafkaListTopic, error)
 	Create(project, service string, req aiven.CreateKafkaTopicRequest) error
 	Update(project, service, topic string, req aiven.UpdateKafkaTopicRequest) error
+	Delete(project, service, topic string) error
 }
 
 type Manager struct {


### PR DESCRIPTION
This patch adds functionality to permanently delete topics.

Permanent deletion requires the annotation:
```
metadata:
  annotations:
    kafka.nais.io/removeDataWhenResourceIsDeleted: "true"
```

If this annotation is set, a _finalizer_ is added to the resource so that Kafkarator can pick it up when it is deleted. On successful deletion, the finalizer is removed so that Kubernetes finally deletes the Topic resource.

A test is provided to avoid code mistakes from accidentally dropping topics.