### PR TITLE
Create secrets matching Aivenator

### DIFF
--- a/controllers/testdata/change_acl.yaml
+++ b/controllers/testdata/change_acl.yaml
@@ -34,8 +34,12 @@ aiven:
     serviceusers:
       - username: myteam.myapplication-6580c2d3
       - username: otherteam.otherapplication-fb9c8478
+      - username: too-long-team.too-long-applicat-eacc7bda
     topics: []
     acls:
+      - username: too-long-team.too-long-applicat-eacc7bda
+        permission: read
+        topic: myteam.mytopic
       - username: myteam.myapplication-6580c2d3
         permission: readwrite
         topic: myteam.mytopic
@@ -62,6 +66,9 @@ topic:
       - access: readwrite
         team: myteam
         application: myapplication
+      - access: read
+        team: too-long-team
+        application: too-long-application
 
 output:
   status:
@@ -131,5 +138,37 @@ output:
         KAFKA_CREDSTORE_PASSWORD: changeme
         KAFKA_SCHEMA_REGISTRY: https://schema-registry.tld:9876
         KAFKA_SCHEMA_REGISTRY_USER: myteam.myapplication-6580c2d3
+        KAFKA_SCHEMA_REGISTRY_PASSWORD: well-known-password
+        KAFKA_SECRET_UPDATED: 1970-01-01T00:00:00Z
+    - apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: kafka-too-long-application-nav-integration-test-e0bd18b9
+        namespace: too-long-team
+        labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: too-long-application
+          team: too-long-team
+          type: aivenator.aiven.nais.io
+        annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: too-long-team.too-long-applicat-eacc7bda
+          kafka.nais.io/application: too-long-application
+          kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
+      data:
+        client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
+        client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore
+      stringData:
+        KAFKA_BROKERS: well-known-kafka-brokers:12345
+        KAFKA_CA: well-known-certificate-authority
+        KAFKA_CERTIFICATE: well-known-access-cert
+        KAFKA_PRIVATE_KEY: well-known-access-key
+        KAFKA_CREDSTORE_PASSWORD: changeme
+        KAFKA_SCHEMA_REGISTRY: https://schema-registry.tld:9876
+        KAFKA_SCHEMA_REGISTRY_USER: too-long-team.too-long-applicat-eacc7bda
         KAFKA_SCHEMA_REGISTRY_PASSWORD: well-known-password
         KAFKA_SECRET_UPDATED: 1970-01-01T00:00:00Z

--- a/controllers/testdata/change_acl.yaml
+++ b/controllers/testdata/change_acl.yaml
@@ -14,9 +14,14 @@ aiven:
         username: otherteam.otherapplication*
         permission: write
         topic: myteam.mytopic
+      - id: acl-3
+        username: myteam.no-wildcard-680515dc
+        permission: readwrite
+        topic: myteam.mytopic
     serviceusers:
       - username: myteam.myapplication-6580c2d3
       - username: otherteam.otherapplication-fb9c8478
+      - username: myteam.no-wildcard-680515dc
     topics:
       - topic_name: myteam.mytopic
     service:
@@ -43,11 +48,15 @@ aiven:
       - username: myteam.myapplication*
         permission: readwrite
         topic: myteam.mytopic
+      - username: myteam.no-wildcard*
+        permission: readwrite
+        topic: myteam.mytopic
   updated:
     topics: {}
   deleted:
     acls:
       - acl-1
+      - acl-3
 
 topic:
   apiVersion: kafka.nais.io/v1
@@ -69,6 +78,9 @@ topic:
       - access: read
         team: too-long-team
         application: too-long-application
+      - access: readwrite
+        team: myteam
+        application: no-wildcard
 
 output:
   status:
@@ -170,5 +182,37 @@ output:
         KAFKA_CREDSTORE_PASSWORD: changeme
         KAFKA_SCHEMA_REGISTRY: https://schema-registry.tld:9876
         KAFKA_SCHEMA_REGISTRY_USER: too-long-team.too-long-applicat-eacc7bda
+        KAFKA_SCHEMA_REGISTRY_PASSWORD: well-known-password
+        KAFKA_SECRET_UPDATED: 1970-01-01T00:00:00Z
+    - apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: kafka-no-wildcard-nav-integration-test-104cf1ba
+        namespace: myteam
+        labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: no-wildcard
+          team: myteam
+          type: aivenator.aiven.nais.io
+        annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: myteam.no-wildcard-680515dc
+          kafka.nais.io/application: no-wildcard
+          kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
+      data:
+        client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
+        client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore
+      stringData:
+        KAFKA_BROKERS: well-known-kafka-brokers:12345
+        KAFKA_CA: well-known-certificate-authority
+        KAFKA_CERTIFICATE: well-known-access-cert
+        KAFKA_PRIVATE_KEY: well-known-access-key
+        KAFKA_CREDSTORE_PASSWORD: changeme
+        KAFKA_SCHEMA_REGISTRY: https://schema-registry.tld:9876
+        KAFKA_SCHEMA_REGISTRY_USER: myteam.no-wildcard-680515dc
         KAFKA_SCHEMA_REGISTRY_PASSWORD: well-known-password
         KAFKA_SECRET_UPDATED: 1970-01-01T00:00:00Z

--- a/controllers/testdata/change_acl.yaml
+++ b/controllers/testdata/change_acl.yaml
@@ -76,10 +76,18 @@ output:
         name: kafka-otherapplication-nav-integration-test-5ed2b9b5
         namespace: otherteam
         labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: otherapplication
           team: otherteam
+          type: aivenator.aiven.nais.io
         annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: otherteam.otherapplication-fb9c8478
           kafka.nais.io/application: otherapplication
           kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
       data:
         client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
         client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore
@@ -100,10 +108,18 @@ output:
         name: kafka-myapplication-nav-integration-test-42edfcd6
         namespace: myteam
         labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: myapplication
           team: myteam
+          type: aivenator.aiven.nais.io
         annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: myteam.myapplication-6580c2d3
           kafka.nais.io/application: myapplication
           kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
       data:
         client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
         client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore

--- a/controllers/testdata/change_acl.yaml
+++ b/controllers/testdata/change_acl.yaml
@@ -7,11 +7,11 @@ aiven:
   existing:
     acls:
       - id: acl-1
-        username: myteam.myapplication-6580c2d3
+        username: myteam.myapplication*
         permission: read
         topic: myteam.mytopic
       - id: acl-2
-        username: otherteam.otherapplication-fb9c8478
+        username: otherteam.otherapplication*
         permission: write
         topic: myteam.mytopic
     serviceusers:
@@ -37,10 +37,10 @@ aiven:
       - username: too-long-team.too-long-applicat-eacc7bda
     topics: []
     acls:
-      - username: too-long-team.too-long-applicat-eacc7bda
+      - username: too-long-team.too-long-applicat*
         permission: read
         topic: myteam.mytopic
-      - username: myteam.myapplication-6580c2d3
+      - username: myteam.myapplication*
         permission: readwrite
         topic: myteam.mytopic
   updated:

--- a/controllers/testdata/greenfield.yaml
+++ b/controllers/testdata/greenfield.yaml
@@ -71,10 +71,18 @@ output:
         name: kafka-myapplication-nav-integration-test-42edfcd6
         namespace: myteam
         labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: myapplication
           team: myteam
+          type: aivenator.aiven.nais.io
         annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: myteam.myapplication-6580c2d3
           kafka.nais.io/application: myapplication
           kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
       data:
         client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
         client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore
@@ -95,10 +103,18 @@ output:
         name: kafka-otherapplication-nav-integration-test-5ed2b9b5
         namespace: otherteam
         labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: otherapplication
           team: otherteam
+          type: aivenator.aiven.nais.io
         annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: otherteam.otherapplication-fb9c8478
           kafka.nais.io/application: otherapplication
           kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
       data:
         client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
         client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore

--- a/controllers/testdata/greenfield.yaml
+++ b/controllers/testdata/greenfield.yaml
@@ -27,10 +27,10 @@ aiven:
       - topic_name: myteam.mytopic
         retention_hours: 900
     acls:
-      - username: myteam.myapplication-6580c2d3
+      - username: myteam.myapplication*
         permission: read
         topic: myteam.mytopic
-      - username: otherteam.otherapplication-fb9c8478
+      - username: otherteam.otherapplication*
         permission: write
         topic: myteam.mytopic
   updated:

--- a/controllers/testdata/update_topic_config.yaml
+++ b/controllers/testdata/update_topic_config.yaml
@@ -74,10 +74,18 @@ output:
         name: kafka-myapplication-nav-integration-test-42edfcd6
         namespace: myteam
         labels:
+          aivenator.aiven.nais.io/migration: "true"
+          app: myapplication
           team: myteam
+          type: aivenator.aiven.nais.io
         annotations:
+          aivenator.aiven.nais.io/protected: "true"
+          kafka.aiven.nais.io/pool: nav-integration-test
+          kafka.aiven.nais.io/serviceUser: myteam.myapplication-6580c2d3
           kafka.nais.io/application: myapplication
           kafka.nais.io/pool: nav-integration-test
+        finalizers:
+          - aivenator.aiven.nais.io/finalizer
       data:
         client.keystore.p12: d2VsbC1rbm93bi1rZXlzdG9yZQ==    # well-known-keystore
         client.truststore.jks: d2VsbC1rbm93bi10cnVzdHN0b3Jl  # well-known-truststore

--- a/controllers/testdata/update_topic_config.yaml
+++ b/controllers/testdata/update_topic_config.yaml
@@ -7,7 +7,7 @@ aiven:
   existing:
     acls:
       - acl_id: well-known-id
-        username: myteam.myapplication-6580c2d3
+        username: myteam.myapplication*
         permission: read
         topic: myteam.mytopic
     serviceusers:

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/aiven/aiven-go-client v1.5.7
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/google/go-cmp v0.5.2
 	github.com/nais/liberator v0.0.0-20210421120235-5f3edcf81f86
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.6.1
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.16
 	k8s.io/apimachinery v0.17.16
 	k8s.io/client-go v0.17.16

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/go-cmp v0.5.2
-	github.com/nais/liberator v0.0.0-20210421120235-5f3edcf81f86
+	github.com/nais/liberator v0.0.0-20210601140848-ee849b24b89d
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/pkg/aiven/acl/acl.go
+++ b/pkg/aiven/acl/acl.go
@@ -2,8 +2,8 @@ package acl
 
 import (
 	"github.com/aiven/aiven-go-client"
-	"github.com/nais/liberator/pkg/apis/kafka.nais.io/v1"
 	"github.com/nais/kafkarator/pkg/metrics"
+	"github.com/nais/liberator/pkg/apis/kafka.nais.io/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
@@ -89,7 +89,7 @@ func (r *Manager) add(toAdd []kafka_nais_io_v1.TopicACL) error {
 		req := aiven.CreateKafkaACLRequest{
 			Permission: topicAcl.Access,
 			Topic:      r.Topic.FullName(),
-			Username:   topicAcl.Username(),
+			Username:   topicAcl.ACLname(),
 		}
 
 		err := metrics.ObserveAivenLatency("ACL_Create", r.Project, func() error {
@@ -163,7 +163,7 @@ func topicACLs(acls []*aiven.KafkaACL, topic string) []*aiven.KafkaACL {
 // returns true if the list of existing ACLs contains an ACL spec from the cluster
 func aclsContainsSpec(acls []*aiven.KafkaACL, aclSpec kafka_nais_io_v1.TopicACL) bool {
 	for _, acl := range acls {
-		if aclSpec.Username() == acl.Username && aclSpec.Access == acl.Permission {
+		if aclSpec.ACLname() == acl.Username && aclSpec.Access == acl.Permission {
 			return true
 		}
 	}
@@ -173,7 +173,7 @@ func aclsContainsSpec(acls []*aiven.KafkaACL, aclSpec kafka_nais_io_v1.TopicACL)
 // returns true if the list of cluster ACL specs contains an existing ACL
 func specsContainsACL(aclSpecs []kafka_nais_io_v1.TopicACL, acl *aiven.KafkaACL) bool {
 	for _, aclSpec := range aclSpecs {
-		if aclSpec.Username() == acl.Username && aclSpec.Access == acl.Permission {
+		if aclSpec.ACLname() == acl.Username && aclSpec.Access == acl.Permission {
 			return true
 		}
 	}

--- a/pkg/aiven/acl/acl_test.go
+++ b/pkg/aiven/acl/acl_test.go
@@ -1,80 +1,96 @@
 package acl_test
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/suite"
+	"gotest.tools/assert"
 	"testing"
 
 	"github.com/aiven/aiven-go-client"
-	"github.com/nais/liberator/pkg/apis/kafka.nais.io/v1"
 	"github.com/nais/kafkarator/pkg/aiven/acl"
-	"github.com/stretchr/testify/assert"
+	"github.com/nais/liberator/pkg/apis/kafka.nais.io/v1"
 )
 
-func TestACLFilter(t *testing.T) {
-	existingACLs := []*aiven.KafkaACL{
-		{
+type ACLFilterTestSuite struct {
+	suite.Suite
+
+	existingACLs []*aiven.KafkaACL
+	aclSpecs     []kafka_nais_io_v1.TopicACL
+	shouldAdd    []kafka_nais_io_v1.TopicACL
+	shouldRemove []*aiven.KafkaACL
+}
+
+func (suite *ACLFilterTestSuite) SetupSuite() {
+	suite.existingACLs = []*aiven.KafkaACL{
+		{ // Delete because of username
 			ID:         "abc",
 			Permission: "read",
 			Topic:      "topic",
 			Username:   "user.app-f1fbd6bd",
 		},
-		{
+		{ // Delete because of wrong permission
 			ID:         "abcde",
 			Permission: "write",
 			Topic:      "topic",
-			Username:   "user.app-f1fbd6bd",
+			Username:   "user.app*",
 		},
-		{
+		{ // Delete because of username and permission
 			ID:         "123",
 			Permission: "read",
 			Topic:      "topic",
 			Username:   "user2.app-4ca551f9",
 		},
-		{
+		{ // Keep
 			ID:         "abcdef",
 			Permission: "write",
 			Topic:      "topic",
-			Username:   "user2.app-4ca551f9",
-		},
-		{
-			ID:         "abc",
-			Permission: "read",
-			Topic:      "not_our_topic",
-			Username:   "user.app-f1fbd6bd",
+			Username:   "user2.app*",
 		},
 	}
 
-	aclSpecs := []kafka_nais_io_v1.TopicACL{
+	suite.aclSpecs = []kafka_nais_io_v1.TopicACL{
+		{ // Added because existing uses wrong username
+			Access:      "read",
+			Team:        "user",
+			Application: "app",
+		},
+		{ // Already exists
+			Access:      "write",
+			Team:        "user2",
+			Application: "app",
+		},
+		{ // Added because of new user
+			Access:      "readwrite",
+			Team:        "user3",
+			Application: "app",
+		},
+	}
+
+	suite.shouldAdd = []kafka_nais_io_v1.TopicACL{
 		{
 			Access:      "read",
 			Team:        "user",
 			Application: "app",
 		},
 		{
-			Access:      "write",
-			Team:        "user2",
-			Application: "app",
-		},
-		{
 			Access:      "readwrite",
 			Team:        "user3",
 			Application: "app",
 		},
 	}
 
-	shouldAdd := []kafka_nais_io_v1.TopicACL{
+	suite.shouldRemove = []*aiven.KafkaACL{
 		{
-			Access:      "readwrite",
-			Team:        "user3",
-			Application: "app",
+			ID:         "abc",
+			Permission: "read",
+			Topic:      "topic",
+			Username:   "user.app-f1fbd6bd",
 		},
-	}
-
-	shouldRemove := []*aiven.KafkaACL{
 		{
 			ID:         "abcde",
 			Permission: "write",
 			Topic:      "topic",
-			Username:   "user.app-f1fbd6bd",
+			Username:   "user.app*",
 		},
 		{
 			ID:         "123",
@@ -83,11 +99,25 @@ func TestACLFilter(t *testing.T) {
 			Username:   "user2.app-4ca551f9",
 		},
 	}
+}
 
-	added := acl.NewACLs(existingACLs, aclSpecs)
-	removed := acl.DeleteACLs(existingACLs, aclSpecs)
+func (suite *ACLFilterTestSuite) TestNewACLs() {
+	added := acl.NewACLs(suite.existingACLs, suite.aclSpecs)
 
-	assert.Equal(t, shouldAdd, added)
+	assert.DeepEqual(suite.T(), suite.shouldAdd, added, cmpopts.SortSlices(func(a, b kafka_nais_io_v1.TopicACL) bool {
+		return a.Application < b.Application
+	}))
+}
 
-	assert.Equal(t, shouldRemove, removed)
+func (suite *ACLFilterTestSuite) TestDeleteACLs() {
+	removed := acl.DeleteACLs(suite.existingACLs, suite.aclSpecs)
+
+	assert.DeepEqual(suite.T(), suite.shouldRemove, removed, cmpopts.SortSlices(func(a, b *aiven.KafkaACL) bool {
+		return a.ID < b.ID
+	}))
+}
+
+func TestACLFilter(t *testing.T) {
+	testSuite := new(ACLFilterTestSuite)
+	suite.Run(t, testSuite)
 }

--- a/pkg/constants/annotations.go
+++ b/pkg/constants/annotations.go
@@ -4,4 +4,9 @@ package constants
 const (
 	PoolAnnotation        = "kafka.nais.io/pool"
 	ApplicationAnnotation = "kafka.nais.io/application"
+
+	// Temporary while migrating to Aivenator
+	ServiceUserAnnotation        = "kafka.aiven.nais.io/serviceUser"
+	AivenatorPoolAnnotation      = "kafka.aiven.nais.io/pool"
+	AivenatorProtectedAnnotation = "aivenator.aiven.nais.io/protected"
 )


### PR DESCRIPTION
Første steg i migrering mot Aivenator, er å sørge for at secrets opprettet av Kafkarator har nødvendig informasjon til at Aivenator kan rydde opp etterpå.
Dette er løst ved å midlertidig legge på nødvendige annotations, labels og finalizer, samt en ekstra label for å identifisere disse secretene i ettertid.
